### PR TITLE
Check to see that the responce back from teams is not ok

### DIFF
--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -280,7 +280,7 @@ class MSTeams {
     const client = new IncomingWebhook(url);
     const response = await client.send(payload);
 
-    if (!response.text) {
+    if (!response.ok) {
       throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
     }
   }


### PR DESCRIPTION
Instead of checking for text check to see that the response from is not in the 2xx range. this is a smaller change than #99. and should allow for all OK responses including when text is provided via a premium teams action.