### PR TITLE
fixing version to 1.4 to work with MS Teams Workflows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1631,11 +1631,7 @@ class MSTeams {
    */
   async notify(url, payload) {
     const client = new IncomingWebhook(url);
-    const response = await client.send(payload);
-
-    if (!response.text) {
-      throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
-    }
+    await client.send(payload);
   }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1614,7 +1614,7 @@ class MSTeams {
             ...mentionedIds
           ],
           '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
-          version: '1.5',
+          version: '1.4',
           msteams: {
             entities: entities
           }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,6 @@
     "type": "git",
     "url": "git+https://github.com/Skitionek/notify-microsoft-teams.git"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run package && git add dist/index.js"
-    }
-  },
   "keywords": [
     "GitHub",
     "Actions",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "type": "git",
     "url": "git+https://github.com/Skitionek/notify-microsoft-teams.git"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run package && git add dist/index.js"
+    }
+  },
   "keywords": [
     "GitHub",
     "Actions",

--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -261,7 +261,7 @@ class MSTeams {
             ...mentionedIds
           ],
           '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
-          version: '1.5',
+          version: '1.4',
           msteams: {
             entities: entities
           }

--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -278,11 +278,13 @@ class MSTeams {
    */
   async notify(url, payload) {
     const client = new IncomingWebhook(url);
-    const response = await client.send(payload);
+    await client.send(payload);
 
-    if (!response.text) {
-      throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
-    }
+    // The new MS Teams Workflow Webhooks will not send you any response body. The client being used only returns the data and not the http status code.
+    // The underlying library throws errors if the response is not 2xx. So, if you are not getting any error, you can assume that the message has been sent successfully.
+    // if (!response.text) {
+    //   throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
+    // }
   }
 }
 


### PR DESCRIPTION
Everything about the AdaptiveCard conversion worked except the fact that it sent over version 1.5. The MS Teams Webhooks won't accept anything above version 1.4. This code isn't actually using any 1.5 features that I could see. Simply dropping the reported version down a number fixed our issues.