### PR TITLE
Update MSTeams.js to not fail if the text is just an empty string

### DIFF
--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -279,9 +279,12 @@ class MSTeams {
   async notify(url, payload) {
     const client = new IncomingWebhook(url);
     const response = await client.send(payload);
-    core.info(response.text)
+    core.info("responsetext'"+response.text+"'")
+    core.info(!response.text)
+    core.info(response.text != "")   
+    core.info(!response.text && response.text != "")
     if (!response.text && response.text != "") {
-      throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
+      throw new Error('Failed to send notification to Microsoft Teams.\n' + '123Response'+response.text +':\n' + JSON.stringify(response, null, 2));
     }
   }
 }

--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -279,8 +279,8 @@ class MSTeams {
   async notify(url, payload) {
     const client = new IncomingWebhook(url);
     const response = await client.send(payload);
-
-    if (!response.text || response.text != "") {
+    core.info(response.text)
+    if (!response.text && response.text != "") {
       throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
     }
   }

--- a/src/MSTeams.js
+++ b/src/MSTeams.js
@@ -280,7 +280,7 @@ class MSTeams {
     const client = new IncomingWebhook(url);
     const response = await client.send(payload);
 
-    if (!response.text) {
+    if (!response.text || response.text != "") {
       throw new Error('Failed to send notification to Microsoft Teams.\n' + 'Response:\n' + JSON.stringify(response, null, 2));
     }
   }


### PR DESCRIPTION
MS teams now sends back responses which include an empty text: Response:
{
  "text": ""
}